### PR TITLE
Add autoselect config example

### DIFF
--- a/pianobar.cfg.example
+++ b/pianobar.cfg.example
@@ -1,6 +1,9 @@
 # Uncomment the control_proxy line if you would like to set up a proxy connection for pianobar
 #control_proxy = http://<proxy_user>:<proxy_pass>@<proxy_address>:<proxy_port>
 
+# Uncomment the autoselect line to automatically start playing most recent station
+# autoselect = 1
+
 user = <pandora_user>
 password = <pandora_password>
 


### PR DESCRIPTION
It's not obvious how to just automatically start playing music.

After find the man pages and first using `autostart_station` I figured out that `autoselect` was what I needed.

This kind of addresses thedmd/pianobar-windows#2 but maybe it's not a fix.
